### PR TITLE
optimize log/log-gamma calculations

### DIFF
--- a/src/pasio.py
+++ b/src/pasio.py
@@ -25,22 +25,25 @@ class LogComputer:
         self.cache_size = cache_size
         self.precomputed = np.log(np.arange(self.cache_size))
 
-    # uses fast algorithm if maximal value of x is specified and doesn't exceed cache size
-    def compute_for_array(self, x, max_value = float('inf')):
-        if max_value < self.cache_size:
-            return self.precomputed[x]
-        else:
-            result = np.zeros(x.shape)
-            is_small = x < self.cache_size
-            result[is_small] = self.precomputed[x[is_small]]
-            result[~is_small] = np.log(x[~is_small])
-            return result
-
     def compute_for_number(self, x):
         if x < self.cache_size:
             return self.precomputed[x]
         else:
             return np.log(x)
+
+    # uses fast algorithm if maximal value of x is specified and doesn't exceed cache size
+    def compute_for_array(self, x, max_value = float('inf')):
+        if max_value < self.cache_size:
+            return self.precomputed[x]
+        else:
+            return self.compute_for_array_non_cached(x)
+
+    def compute_for_array_non_cached(self, x):
+        result = np.zeros(x.shape)
+        is_small = x < self.cache_size
+        result[is_small] = self.precomputed[x[is_small]]
+        result[~is_small] = np.log(x[~is_small])
+        return result
 
 # Works only with non-negative integer values
 class LogGammaComputer:
@@ -59,11 +62,14 @@ class LogGammaComputer:
         if max_value < self.cache_size:
             return self.precomputed[x]
         else:
-            result = np.zeros(x.shape)
-            is_small = x < self.cache_size
-            result[is_small] = self.precomputed[x[is_small]]
-            result[~is_small] = scipy.special.gammaln(x[~is_small])
-            return result
+            return self.compute_for_array_non_cached(x)
+
+    def compute_for_array_non_cached(self, x):
+        result = np.zeros(x.shape)
+        is_small = x < self.cache_size
+        result[is_small] = self.precomputed[x[is_small]]
+        result[~is_small] = scipy.special.gammaln(x[~is_small])
+        return result
 
 cached_log = LogComputer()
 log_gamma = LogGammaComputer()


### PR DESCRIPTION
Now log calculator and log-gamma calculators now doesn't try to guess argument type (array or single number), we specify calculation type directly.