### PR TITLE
Fix bedGraph reading 

### DIFF
--- a/pasio/__init__.py
+++ b/pasio/__init__.py
@@ -7,6 +7,7 @@ from .log_marginal_likelyhood import LogMarginalLikelyhoodComputer, LogMarginalL
 from .cached_log import LogComputer, LogGammaComputer
 from .nop_splitter import NopSplitter
 from .process_bedgraph import parse_bedgraph, split_bedgraph
+from .slice_when import slice_when
 
 __all__ = [
     SquareSplitter,
@@ -17,5 +18,6 @@ __all__ = [
     NopSplitter,
     LogComputer, LogGammaComputer,
     LogMarginalLikelyhoodComputer, LogMarginalLikelyhoodIntAlphaComputer, LogMarginalLikelyhoodRealAlphaComputer, ScorerFactory,
-    parse_bedgraph, split_bedgraph
+    parse_bedgraph, split_bedgraph,
+    slice_when,
 ]

--- a/pasio/cli.py
+++ b/pasio/cli.py
@@ -54,8 +54,11 @@ python pasio.py
                            If not set, run until no split points removed''')
     argparser.add_argument('--no_split_constant', action='store_true',
                            help = '''[experimental] If set, won't put splits between constant counts''')
+    argparser.add_argument('--split_at_gaps', action='store_true',
+                           help = 'By default gaps between intervals are filled with zeros.\n' +
+                                  'Split at gaps overrides this behavior so that\n' +
+                                  'non-adjacent intervals are segmented independently.')
     return argparser
-
 
 def configure_splitter(args):
     if args.algorithm in ['slidingwindow', 'rounds']:
@@ -116,4 +119,4 @@ def main():
     logger.info("Pasio:"+ str(args))
     splitter = configure_splitter(args)
     logger.info('Starting Pasio with args'+str(args))
-    split_bedgraph(args.bedgraph, args.out_bedgraph, splitter)
+    split_bedgraph(args.bedgraph, args.out_bedgraph, splitter, split_at_gaps=args.split_at_gaps)

--- a/pasio/process_bedgraph.py
+++ b/pasio/process_bedgraph.py
@@ -9,9 +9,10 @@ def parse_bedgraph(filename):
     previous_chrom = None
     with open(filename) as bedgraph_file:
         for line in bedgraph_file:
-            if line.strip() == '':
+            line = line.strip()
+            if line == '':
                 continue
-            chrom, start, stop, coverage = line.strip().split()[0:4]
+            chrom, start, stop, coverage = line.split()[0:4]
             start = int(start)
             stop = int(stop)
             coverage = int(coverage)

--- a/pasio/process_bedgraph.py
+++ b/pasio/process_bedgraph.py
@@ -1,6 +1,7 @@
 import numpy as np
 from .logging import logger
 import itertools
+from .slice_when import slice_when
 
 def bedgraph_intervals(filename):
     with open(filename) as bedgraph_file:
@@ -14,29 +15,66 @@ def bedgraph_intervals(filename):
             coverage = int(coverage)
             yield (chrom, start, stop, coverage)
 
-def group_by_chromosome(intervals):
-    return itertools.groupby(intervals, key=lambda (chrom, start, stop, coverage): chrom)
+def get_interval_chromosome(interval):
+    chrom, start, stop, coverage = interval
+    return chrom
 
-def parse_bedgraph(filename):
+def group_by_chromosome(intervals):
+    return itertools.groupby(intervals, key=get_interval_chromosome)
+
+def fill_interval_gaps(intervals):
+    previous_stop = None
+    for interval in intervals:
+        chrom, start, stop, coverage = interval
+        if previous_stop and (previous_stop != start):
+            yield (chrom, previous_stop, start, 0)
+        yield interval
+        previous_stop = stop
+
+def intervals_not_adjacent(interval_1, interval_2):
+    chrom_1, start_1, stop_1, coverage_1 = interval_1
+    chrom_2, start_2, stop_2, coverage_2 = interval_2
+    return stop_1 != start_2
+
+def interval_groups(intervals, split_at_gaps):
+    '''
+    Yield groups of adjacent intervals in a fashion similar to itertools.groupby.
+    If `split_at_gaps` is False, uncovered chromosome positions (gaps) are filled with 0-s
+    If `split_at_gaps` is True, positions missing in bedgraph are treated as separators
+     and divide chromosome into independent parts
+    Flanking regions (i.e. chromosome ends) are not filled with gaps because
+      we don't know chromosome length (thus cannot replace right end with zeros)
+      and symmetrically doesn't fill left end for consistency reasons
+    '''
+    for chromosome, chromosome_intervals in group_by_chromosome(intervals):
+        if split_at_gaps:
+            for intervals_group in slice_when(chromosome_intervals, condition=intervals_not_adjacent):
+                yield intervals_group
+        else:
+            yield fill_interval_gaps(chromosome_intervals)
+
+def parse_bedgraph(filename, split_at_gaps=False):
     '''
         yields pointwise profiles grouped by chromosome in form (chrom, profile, chromosome_start)
     '''
-    for chromosome, intervals in group_by_chromosome(bedgraph_intervals(filename)):
-        chromosome_start = None
+    for intervals_group in interval_groups(bedgraph_intervals(filename), split_at_gaps=split_at_gaps):
         chromosome_data = []
-        for (_, start, stop, coverage) in intervals:
+        chromosome_start = None
+        chromosome = None
+        for (chrom, start, stop, coverage) in intervals_group:
             if chromosome_start is None:
                 chromosome_start = start
+                chromosome = chrom
             chromosome_data.extend([coverage]*(stop-start))
         # overwrite chromosome_data not to retain both list and np.array in memory
         # and let the former be garbage collected
         chromosome_data = np.array(chromosome_data, dtype=int)
         yield chromosome, chromosome_data, chromosome_start
 
-def split_bedgraph(in_filename, out_filename, splitter):
+def split_bedgraph(in_filename, out_filename, splitter, split_at_gaps):
     with open(out_filename, 'w') as outfile:
         logger.info('Reading input file %s' % (in_filename))
-        for chrom, counts, chrom_start in parse_bedgraph(in_filename):
+        for chrom, counts, chrom_start in parse_bedgraph(in_filename, split_at_gaps=split_at_gaps):
             logger.info('Starting chrom %s of length %d' % (chrom, len(counts)))
             split_candidates = np.arange(len(counts) + 1)
             score, splits = splitter.split(counts, split_candidates)

--- a/pasio/process_bedgraph.py
+++ b/pasio/process_bedgraph.py
@@ -11,7 +11,7 @@ def parse_bedgraph(filename):
         for line in bedgraph_file:
             if line.strip() == '':
                 continue
-            chrom, start, stop, coverage = line.strip().split()
+            chrom, start, stop, coverage = line.strip().split()[0:4]
             start = int(start)
             stop = int(stop)
             coverage = int(coverage)

--- a/pasio/slice_when.py
+++ b/pasio/slice_when.py
@@ -1,0 +1,39 @@
+# Analog for ruby method Enumerable#slice_when.
+# Implemented similarly to groupby
+class slice_when:
+    def __init__(self, iterable, condition):
+        self.it = iter(iterable)
+        self.slice_condition = condition
+        self.first_element = True
+        self.finished = False
+        self.cur_group = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.first_element:
+            # For empty list it can raise StopIteration immediately, that's expected behavior
+            self.cur_value = next(self.it)
+            self.first_element = False
+        if self.finished:
+            raise StopIteration
+        if self.cur_group:
+            for _ in self.cur_group: # exhaust group
+                pass
+        self.cur_group = self._group_iterator()
+        return self.cur_group
+    
+    next = __next__
+
+    def _group_iterator(self):
+        while True:
+            yield self.cur_value
+            try:
+                self.prev_value = self.cur_value
+                self.cur_value  = next(self.it)
+                if self.slice_condition(self.prev_value, self.cur_value):
+                    return
+            except StopIteration:
+                self.finished = True
+                return

--- a/test/test_pasio.py
+++ b/test/test_pasio.py
@@ -242,6 +242,7 @@ def test_bedgraph_reader(tmpdir):
         chr2 50 60 0
         ''')
     chromosomes = {k:v for (k,v,l) in pasio.parse_bedgraph(str(bedgraph_file))}
+    print(list(pasio.parse_bedgraph(str(bedgraph_file))))
     assert len(chromosomes) == 2
     assert len(chromosomes['chr1']) == 50
     assert np.all(chromosomes['chr1'][0:10] == 0)

--- a/test/test_slice_when.py
+++ b/test/test_slice_when.py
@@ -1,0 +1,28 @@
+from pasio import slice_when
+
+def test_slice_when():
+    big_diff = lambda x,y: x + 1 < y
+    assert [list(g) for g in slice_when([1,2,3,7,8,9],       big_diff)] == [[1,2,3], [7,8,9]]
+    assert [list(g) for g in slice_when([1,2,3,7,8,9,99],    big_diff)] == [[1,2,3], [7,8,9], [99]]
+    assert [list(g) for g in slice_when([-5,1,2,3,7,8,9],    big_diff)] == [[-5], [1,2,3], [7,8,9]]
+    assert [list(g) for g in slice_when([1,2,3],             big_diff)] == [[1,2,3]]
+    assert [list(g) for g in slice_when([],                  big_diff)] == []
+    assert [list(g) for g in slice_when([1],                 big_diff)] == [[1]]
+    assert [list(g) for g in slice_when([1, 1],              big_diff)] == [[1, 1]]
+    assert [list(g) for g in slice_when([1, 1],              big_diff)] == [[1, 1]]
+    assert [list(g) for g in slice_when([1, 1.5],             big_diff)] == [[1, 1.5]]
+    assert [list(g) for g in slice_when([1,1,1, 3,3, 5,5,5], big_diff)] == [[1,1,1], [3,3], [5,5,5]]
+
+    # exhausts a group, when you request next group
+    sl = slice_when([1,1,1, 3,3, 5,5,5], big_diff)
+    next(sl)
+    assert [list(g) for g in sl] == [[3,3], [5,5,5]]
+
+    # exhausts group from which elements were picked, when you request next group
+    sl = slice_when([1,1,1, 3,3, 5,5,5], big_diff)
+    it = next(sl)
+    next(it)
+    assert [list(g) for g in sl] == [[3,3], [5,5,5]]
+
+    # works with iterators
+    assert [list(g) for g in slice_when(range(5), big_diff)] == [[0,1,2,3,4]]


### PR DESCRIPTION
so that gaps in data were autofilled with zeros. Optionally `--split_at_gaps` can split such non-adjacent intervals independently.